### PR TITLE
Add unix socket support

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -1,5 +1,6 @@
 {
   "app": {
+    "unixSocket": false,
     "port": 31339,
     "host": "127.0.0.1"
   },

--- a/index.js
+++ b/index.js
@@ -27,8 +27,11 @@ const routes = require('./src/routes')
 const port = config.get('app.port')
 const host = config.get('app.host')
 const unixSocket = (
-  config.has('app.unixSocket') &&
-  config.get('app.unixSocket')
+  process.env.UNIX_SOCKET ||
+  (
+    config.has('app.unixSocket') &&
+    config.get('app.unixSocket')
+  )
 )
 
 app.use(corsService.corsBase())
@@ -52,7 +55,7 @@ app.use(notFoundMiddleware)
 app.use(errorsMiddleware)
 
 const args = unixSocket && typeof unixSocket === 'string'
-  ? [unixSocket]
+  ? [unixSocket.trim()]
   : [port, host]
 
 if (args.length === 1) {


### PR DESCRIPTION
This PR adds unix socket support.
To set the path to the file, need to change the `unixSocket` parameter in the configuration file `config/default.json`
Adds the ability to override the path to the socket by setting the UNIX_SOCKET environment variable