### PR TITLE
Increase peer request timeout

### DIFF
--- a/src/services/grenacheClient.service.js
+++ b/src/services/grenacheClient.service.js
@@ -22,7 +22,7 @@ const link = new Link({
 
 link.start()
 
-const peer = new Peer(link, {})
+const peer = new Peer(link, { requestTimeout: 90000 })
 
 peer.init()
 


### PR DESCRIPTION
This PR increases peer request timeout to 90s, it related to the timeout on the rate limit error of the `api_v2`