### PR TITLE
New auth way

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-express",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Express server of reporting tool",
   "main": "index.js",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ws": "^7.0.0"
   },
   "devDependencies": {
-    "standard": "^12.0.1",
+    "standard": "^14.3.3",
     "nodemon": "^1.18.9"
   },
   "nodemonConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-express",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Express server of reporting tool",
   "main": "index.js",
   "engine": {
@@ -11,6 +11,11 @@
     "url": "git+https://github.com/bitfinexcom/bfx-report-express.git"
   },
   "license": "Apache-2.0",
+  "contributors": [
+    "Vladimir Voronkov <vsvoronkov@gmail.com>",
+    "Paolo Ardoino <paolo@btifinex.com>",
+    "Ezequiel Wernicke <ezequiel.wernicke@bitfinex.com>"
+  ],
   "keywords": [
     "bitfinex"
   ],

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -46,7 +46,7 @@ const checkStoredLocally = async (req, res) => {
   success(200, { result: email, id }, res)
 }
 
-const getData = async (req, res) => {
+const jsonRpc = async (req, res) => {
   const body = { ...req.body }
   const {
     id = null,
@@ -65,5 +65,5 @@ const getData = async (req, res) => {
 
 module.exports = {
   checkStoredLocally,
-  getData
+  jsonRpc
 }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -6,40 +6,10 @@ const {
 } = require('../services')
 const { success } = helpers.responses
 
-const checkAuth = async (req, res) => {
-  const id = req.body.id || null
-  const query = {
-    action: 'getEmail',
-    args: [req.body]
-  }
-
-  const isSyncMode = await gClientService.request({
-    ...query,
-    action: 'isSyncModeConfig'
-  })
-
-  if (isSyncMode) {
-    await gClientService.request({
-      ...query,
-      action: 'login'
-    })
-
-    success(200, { result: true, id }, res)
-
-    return
-  }
-
-  const result = await gClientService.request(query)
-
-  if (!result) {
-    throw new Error('ERR_AUTH_UNAUTHORIZED')
-  }
-
-  success(200, { result: true, id }, res)
-}
-
 const checkStoredLocally = async (req, res) => {
-  const id = req.body.id || null
+  const body = { ...req.body }
+  const { id = null } = body
+
   const queryS3 = {
     action: 'lookUpFunction',
     args: [{
@@ -52,28 +22,39 @@ const checkStoredLocally = async (req, res) => {
       params: { service: 'rest:ext:sendgrid' }
     }]
   }
-  const queryGetEmail = {
-    action: 'getEmail',
-    args: [req.body]
+  const queryGetUser = {
+    action: 'verifyUser',
+    args: [body]
   }
 
-  const countS3Services = await gClientService.request(queryS3)
-  const countSendgridServices = await gClientService.request(querySendgrid)
-  let result = false
+  const countS3Services = await gClientService
+    .request(queryS3)
+  const countSendgridServices = await gClientService
+    .request(querySendgrid)
 
-  if (countS3Services && countSendgridServices) {
-    result = await gClientService.request(queryGetEmail)
+  if (
+    !countS3Services ||
+    !countSendgridServices
+  ) {
+    success(200, { result: false, id }, res)
+
+    return
   }
 
-  success(200, { result, id }, res)
+  const { email } = await gClientService
+    .request(queryGetUser)
+  success(200, { result: email, id }, res)
 }
 
 const getData = async (req, res) => {
   const body = { ...req.body }
-  const id = body.id || null
+  const {
+    id = null,
+    method: action = ''
+  } = body
   delete body.method
   const query = {
-    action: req.body.method || '',
+    action,
     args: [body]
   }
 
@@ -83,7 +64,6 @@ const getData = async (req, res) => {
 }
 
 module.exports = {
-  checkAuth,
   checkStoredLocally,
   getData
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,4 +10,4 @@ const controllers = require('../controllers')
 const baseController = asyncErrorCatcher(controllers.baseController)
 
 router.post('/check-stored-locally', baseController.checkStoredLocally)
-router.post('/get-data', baseController.getData)
+router.post('/json-rpc', baseController.jsonRpc)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -11,3 +11,9 @@ const baseController = asyncErrorCatcher(controllers.baseController)
 
 router.post('/check-stored-locally', baseController.checkStoredLocally)
 router.post('/json-rpc', baseController.jsonRpc)
+
+/**
+ * @deprecated
+ * The endpoint will be removed in the future, now need to use `/json-rpc` one
+ */
+router.post('/get-data', baseController.jsonRpc)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,5 @@ const { asyncErrorCatcher } = require('../services/helpers')
 const controllers = require('../controllers')
 const baseController = asyncErrorCatcher(controllers.baseController)
 
-router.post('/check-auth', baseController.checkAuth)
 router.post('/check-stored-locally', baseController.checkStoredLocally)
 router.post('/get-data', baseController.getData)

--- a/src/services/log.service.js
+++ b/src/services/log.service.js
@@ -174,7 +174,7 @@ if (enableConsole) {
   })
 }
 
-let arrLogTransports = Object.values(logTransports)
+const arrLogTransports = Object.values(logTransports)
 
 const logger = createLogger({
   levels: loggerConfig.levels,

--- a/src/services/logDebug.service.js
+++ b/src/services/logDebug.service.js
@@ -11,7 +11,7 @@ const enableInfo = isEnable
 const enableDev = isEnable
 const enableError = isEnable
 
-let _token = []
+const _token = []
 
 const infoToken = `${prefix}info${postfix}`
 const devToken = `${prefix}dev${postfix}`


### PR DESCRIPTION
This PR adds support for a new auth way. Basic changes:
  - removes `/check-auth` endpoint from the express layer, now need to use `verifyUser` method from the main grenache service
  - renames `/get-data` endpoint to `/json-rpc` as more readable
  - bumps standard version up to 14

**Depends** on this PR https://github.com/bitfinexcom/bfx-report/pull/174