### PR TITLE
Add auth route to verify user by token

### DIFF
--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -20,6 +20,37 @@ const jsonRpc = async (req, res) => {
   jsonRpcResponder(req, res, rpcRes)
 }
 
+const auth = async (req, res) => {
+  const xAuthTokenHeader = req.headers?.['x-auth-token']
+  const xOriginalURIHeader = req.headers?.['x-original-uri']
+  const params = xOriginalURIHeader.split('?')[1]
+
+  const queryToken = req.query?.token ?? null
+  const uriToken = new URLSearchParams(params).get('token')
+  const headerToken = (uriToken && typeof uriToken === 'string')
+    ? uriToken
+    : xAuthTokenHeader
+  const token = (queryToken && typeof queryToken === 'string')
+    ? queryToken
+    : headerToken
+
+  if (!token) {
+    res.status(401).send()
+
+    return
+  }
+
+  const query = {
+    action: 'verifyUser',
+    args: [{ auth: { token } }]
+  }
+
+  const rpcRes = await grenacheClientService.request(query)
+
+  jsonRpcResponder(req, res, rpcRes)
+}
+
 module.exports = {
-  jsonRpc
+  jsonRpc,
+  auth
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ const controllers = require('../controllers')
 const baseController = asyncErrorCatcher(controllers.baseController)
 
 router.post('/json-rpc', baseController.jsonRpc)
+router.get('/auth', baseController.auth)
 
 /**
  * @deprecated


### PR DESCRIPTION
This PR adds `/auth` route to verify the user by token
The idea is the following:
  - have the ability to get reports files using the NGINX autoindex option
  - to restrict access for unauth users NGINX would use `/auth` route with a user token
  - token can be passed in:
    - query param: `/auth?token=123-user-token-321`
    - query param of `x-original-uri` HTTP header: `x-original-uri: /auth?token=123-user-token-321`
    - `x-auth-token` HTTP heder: `x-auth-token: 123-user-token-321`