### PR TITLE
Add ability to overwrite rpc timeout

### DIFF
--- a/src/services/grenacheClient.service.js
+++ b/src/services/grenacheClient.service.js
@@ -13,6 +13,8 @@ const logger = new CustomLogger({
 }).createLogger()
 
 const gClientConf = config.get('grenacheClient')
+const appConfig = config.get('app')
+const httpRpcTimeout = appConfig?.httpRpcTimeout ?? 90000
 
 const Peer = Grenache.PeerRPCClient
 
@@ -22,7 +24,7 @@ const link = new Link({
 
 link.start()
 
-const peer = new Peer(link, { requestTimeout: 90000 })
+const peer = new Peer(link, { requestTimeout: httpRpcTimeout })
 
 peer.init()
 
@@ -31,7 +33,7 @@ const request = (query, cb) => {
     peer.request(
       gClientConf.query,
       query,
-      { timeout: 90000 },
+      { timeout: httpRpcTimeout },
       (err, data) => {
         if (err) {
           logger.debug(`Found error at ${err.stack || err}`)

--- a/src/services/initWebSocket.service.js
+++ b/src/services/initWebSocket.service.js
@@ -19,6 +19,8 @@ const {
   grape,
   query
 } = config.get('grenacheClient')
+const appConfig = config.get('app')
+const wsRpcTimeout = appConfig?.wsRpcTimeout ?? 90000
 
 const _sendData = (ws, data) => {
   if (ws.readyState !== WebSocket.OPEN) {
@@ -195,7 +197,7 @@ module.exports = (server) => {
         ws.on('message', (data) => {
           const payload = transport.parse(data)
 
-          peer.request(key, payload, { timeout: 10000 }, (err, result) => {
+          peer.request(key, payload, { timeout: wsRpcTimeout }, (err, result) => {
             if (err) {
               _sendError(ws, err, payload)
 

--- a/src/services/initWebSocket.service.js
+++ b/src/services/initWebSocket.service.js
@@ -64,8 +64,8 @@ const _sendJsonRpcResponse = (ws, data, body) => {
       this.code = code
     },
     json (rpcRes) {
-      if (reqAdapter.action) {
-        rpcRes.action = reqAdapter.action
+      if (reqAdapter?.body?.action) {
+        rpcRes.action = reqAdapter?.body?.action
       }
 
       _sendData(ws, rpcRes)


### PR DESCRIPTION
This PR adds ability to overwrite `RPC` timeout

---

The idea is to have `httpRpcTimeout` and `wsRpcTimeout` options that can be overwritten in the electron environment for complicated reports which can have a lot of internal calls to the `BFX API` that can take significant time
By default:
- `httpRpcTimeout` will be used hardcoded `90s` timeout, as earlier 
- `wsRpcTimeout` will be used hardcoded `90s` timeout, earlier it was `10s`

Also adds a fix to provide `action` field for error response by WS