### PR TITLE
Remove lodash usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "grenache-nodejs-http": "0.7.12",
         "grenache-nodejs-link": "0.7.12",
         "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
-        "lodash": "4.17.21",
         "morgan": "1.10.0",
         "winston": "3.3.3",
         "ws": "8.2.3"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "grenache-nodejs-http": "0.7.12",
     "grenache-nodejs-link": "0.7.12",
     "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
-    "lodash": "4.17.21",
     "morgan": "1.10.0",
     "winston": "3.3.3",
     "ws": "8.2.3"


### PR DESCRIPTION
This PR removes the `lodash` usage from `package.json` and `package-lock.json` as redundant and not used anywhere in the code