### PR TITLE
Use grenache-grape from npm repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -198,8 +198,8 @@
       }
     },
     "node_modules/@bitfinex/bfx-report": {
-      "version": "5.0.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report.git#bb4136cb86efe423ad23626bd507fcfc023b7320",
+      "version": "5.1.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report.git#762548c2441e95c81f0f86765399984440531cd3",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
         "chai": "4.5.0",
         "cross-env": "10.1.0",
-        "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
+        "grenache-grape": "1.0.0",
         "mocha": "11.7.5",
         "nodemon": "3.1.11",
         "standard": "17.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@bitfinex/bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",
-        "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
+        "bfx-api-mock-srv": "2.0.0",
         "chai": "4.5.0",
         "cross-env": "10.1.0",
         "grenache-grape": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
     "chai": "4.5.0",
     "cross-env": "10.1.0",
-    "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
+    "grenache-grape": "1.0.0",
     "mocha": "11.7.5",
     "nodemon": "3.1.11",
     "standard": "17.1.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@bitfinex/bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",
-    "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
+    "bfx-api-mock-srv": "2.0.0",
     "chai": "4.5.0",
     "cross-env": "10.1.0",
     "grenache-grape": "1.0.0",


### PR DESCRIPTION
This PR uses `grenache-grape` dep from npm repository. Also, updates `@bitfinex/bfx-report`, uses `bfx-api-mock-srv` from npm repo